### PR TITLE
bump version to 1.0.12 and mark that as stable

### DIFF
--- a/bluehost-site-migrator.php
+++ b/bluehost-site-migrator.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Bluehost Site Migrator
  * Plugin URI:        https://wordpress.org/plugins/bluehost-site-migrator
  * Description:       Quickly and easily migrate your website to Bluehost.
- * Version:           1.0.9
+ * Version:           1.0.12
  * Requires PHP:      5.6
  * Requires at least: 4.7
  * Author:            Bluehost
@@ -22,7 +22,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  */
 
-define( 'BH_SITE_MIGRATOR_VERSION', '1.0.9' );
+define( 'BH_SITE_MIGRATOR_VERSION', '1.0.12' );
 define( 'BH_SITE_MIGRATOR_FILE', __FILE__ );
 define( 'BH_SITE_MIGRATOR_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BH_SITE_MIGRATOR_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bluehost, wpscholar
 Tags: migrate, migration
 Requires at least: 4.7
 Tested up to: 6.2
-Stable tag: 1.0.9
+Stable tag: 1.0.12
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -23,6 +23,15 @@ Important:  You will need a Bluehost hosting account for this plugin to complete
 3. Click on the "Site Migrator" link on the left-hand menu in the WordPress admin to get started!
 
 == Upgrade Notice ==
+
+= 1.0.12 =
+* Bump up latest tested version for public view.
+
+= 1.0.11 =
+* Release workflow updates.
+
+= 1.0.10 =
+* Fixes migrations stuck on packaging dropins and plugins.
 
 = 1.0.9 =
 * Maintenance update and performance improvements.


### PR DESCRIPTION
A PR to bump the latest version so that wordpress org shows 1.0.12 as stable.
Added update logs